### PR TITLE
as_hash method

### DIFF
--- a/lib/dish/plate.rb
+++ b/lib/dish/plate.rb
@@ -14,6 +14,10 @@ module Dish
       end
     end
 
+    def as_hash
+      @dish_original_hash
+    end
+
     private
 
       attr_reader :dish_original_hash

--- a/lib/dish/version.rb
+++ b/lib/dish/version.rb
@@ -1,3 +1,3 @@
 module Dish
-  VERSION = "0.0.3"
+  VERSION = "0.0.2"
 end

--- a/lib/dish/version.rb
+++ b/lib/dish/version.rb
@@ -1,3 +1,3 @@
 module Dish
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/test/dish_test.rb
+++ b/test/dish_test.rb
@@ -77,8 +77,8 @@ class DishTest < Test::Unit::TestCase
       }
     }
     dish = Dish(hash)
-    c_hash = hash.c.as_hash
-    assert_equal "Hash", hash.c.as_hash.class.to_s
+    c_hash = dish.c.as_hash
+    assert_equal "Hash", dish.c.as_hash.class.to_s
     assert_equal hash["c"]["1"], c_hash["1"]
     assert_equal hash["c"]["2"], c_hash["2"]
   end

--- a/test/dish_test.rb
+++ b/test/dish_test.rb
@@ -77,7 +77,10 @@ class DishTest < Test::Unit::TestCase
       }
     }
     dish = Dish(hash)
+    c_hash = hash.c.as_hash
     assert_equal "Hash", hash.c.as_hash.class.to_s
+    assert_equal hash["c"]["1"], c_hash["1"]
+    assert_equal hash["c"]["2"], c_hash["2"]
   end
 
   def test_hash_ext

--- a/test/dish_test.rb
+++ b/test/dish_test.rb
@@ -67,6 +67,19 @@ class DishTest < Test::Unit::TestCase
     assert_nil Dish(nil)
   end
 
+  def test_as_hash
+    hash = {
+      "a" => "a",
+      "b" => "b",
+      "c" => {
+        "1" => 1,
+        "2" => 2
+      }
+    }
+    dish = Dish(hash)
+    assert_equal "Hash", hash.c.as_hash.class.to_s
+  end
+
   def test_hash_ext
     hash = { a: 1, b: 2 }
     dish = hash.to_dish


### PR DESCRIPTION
Returns the original hash, useful for sub hashes
