### PR TITLE
Define #key=(value) and #methods on Dish::Plate

### DIFF
--- a/lib/dish/plate.rb
+++ b/lib/dish/plate.rb
@@ -16,9 +16,12 @@ module Dish
 
     def method_missing(method, *args, &block)
       method = method.to_s
-      if method.end_with?("?")
+      if method.end_with? '?'
         key = method[0..-2]
         _check_for_presence(key)
+      elsif method.end_with? '='
+        key = camel_case_key[0..-2]
+        _set_value(key, args.first)
       else
         _get_value(method)
       end
@@ -37,6 +40,11 @@ module Dish
         _convert_value(value, self.class.coercions[key])
       end
 
+      def _set_value(key, value)
+        value = _convert_value(value, self.class.coercions[key])
+        @_original_hash[key] = value
+      end
+ 
       def _check_for_presence(key)
         !!_get_value(key)
       end

--- a/lib/dish/plate.rb
+++ b/lib/dish/plate.rb
@@ -16,14 +16,22 @@ module Dish
 
     def method_missing(method, *args, &block)
       method = method.to_s
+      key = method[0..-2]
+
       if method.end_with? '?'
-        key = method[0..-2]
         _check_for_presence(key)
       elsif method.end_with? '='
-        key = camel_case_key[0..-2]
         _set_value(key, args.first)
       else
         _get_value(method)
+      end
+    end
+
+    def respond_to_missing?(method, *args)
+      if as_hash.keys.include?(method.to_s)
+        true
+      else
+        super
       end
     end
 

--- a/lib/dish/plate.rb
+++ b/lib/dish/plate.rb
@@ -27,6 +27,11 @@ module Dish
       end
     end
 
+    def methods(regular = true)
+      valid_keys = as_hash.keys.map(&:to_sym)
+      valid_keys + super
+    end
+
     def as_hash
       @_original_hash
     end

--- a/test/dish_test.rb
+++ b/test/dish_test.rb
@@ -39,6 +39,11 @@ class DishTest < Test::Unit::TestCase
     assert_equal true,       book.title?
     assert_equal false,      book.active
     assert_equal false,      book.active?
+
+
+    book.active = nil
+    assert_equal nil,   book.active
+    assert_equal false, book.active?
   end
 
   def test_hash_helper


### PR DESCRIPTION
In response to #2: 
- Adds support for #key_name= methods
- Displays the keys in #methods
