### PR TITLE
Use #to_h instead of #as_hash for retreiving the original hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,27 +40,28 @@ Then run:
 
 And you're good to go.
 
-Note: If you're using Dish with the BubbleWrap JSON module, please see below.
+**NOTE:** If you're using Dish with the BubbleWrap JSON module, please see below.
 
 ## Example
+```ruby
+hash = {
+  title: "My Title",
+  authors: [
+    { id: 1, name: "Mike Anderson" },
+    { id: 2, name: "Well D." }
+  ],
+  active: false
+}
 
-    hash = {
-      title: "My Title",
-      authors: [
-        { id: 1, name: "Mike Anderson" },
-        { id: 2, name: "Well D." }
-      ],
-      active: false
-    }
-
-    book = Dish(hash) # or hash.to_dish if you required "dish/ext"
-    book.title           # => "My Title"
-    book.authors.length  # => 2
-    book.authors[1].name # => "Well D."
-    book.title?          # => true
-    book.active?         # => false
-    book.other           # => nil
-    book.other?          # => false
+book = Dish(hash) # or hash.to_dish if you required "dish/ext"
+book.title           # => "My Title"
+book.authors.length  # => 2
+book.authors[1].name # => "Well D."
+book.title?          # => true
+book.active?         # => false
+book.other           # => nil
+book.other?          # => false
+```
 
 ## Coercion
 
@@ -110,25 +111,29 @@ This is inspired by [Hashie](https://github.com/intridea/hashie)'s coercion meth
 
 Have fun!
 
-## Accessing the original hash
+## Converting back to Ruby/JSON objects
 
-You can use the `as_hash` method for accessing the original hash.
+You can use the `Dish::Plate#to_h` method for accessing the original hash. In addition `Dish::Plate#to_json` can be used for marshaling JSON if you are using RubyMotion (`NSJSONSerialization` is used) or have required [the "json" Ruby stdlib](http://www.ruby-doc.org/stdlib/libdoc/json/rdoc/JSON.html).
+
+**NOTE:** Previously `Dish::Plate#to_h` was called `Dish::Plate#as_hash`. The `Dish::Plate#as_hash` method is now deprecated.
 
 ## Notes
 
 ### Using with the BubbleWrap JSON module
 
 When you use the [BubbleWrap](https://github.com/rubymotion/BubbleWrap) gem to parse JSON into a hash, you can't use the
-`to_dish` methods directly because the `BW::JSON` module returns some sort of hash that hasn't got the methods from the real hash. I'm
+`Hash#to_dish` methods directly because the `BW::JSON` module returns some sort of hash that hasn't got the methods from the real hash. I'm
 fixing this, but in the meanwhile you can achieve the same result by doing this:
 
-    BW::HTTP.get("http://path.to/api/books/2") do |response|
-      json = BW::JSON.parse(response.body.to_s)
-      book = Dish(json) # This is the actual conversion
+```ruby
+BW::HTTP.get("http://path.to/api/books/2") do |response|
+  json = BW::JSON.parse(response.body.to_s)
+  book = Dish(json) # This is the actual conversion
 
-      title_label.text = book.title
-      author_label.text = book.authors.map(&:name).join(", ")
-    end
+  title_label.text = book.title
+  author_label.text = book.authors.map(&:name).join(", ")
+end
+```
 
 ## Contributing
 

--- a/lib/dish/plate.rb
+++ b/lib/dish/plate.rb
@@ -24,9 +24,11 @@ module Dish
       end
     end
 
-    def as_hash
+    def to_h
       @_original_hash
     end
+
+    alias_method :as_hash, :to_h
 
     private
 

--- a/lib/dish/plate.rb
+++ b/lib/dish/plate.rb
@@ -31,7 +31,15 @@ module Dish
     alias_method :as_hash, :to_h
 
     def to_json(*args)
-      to_h.to_json(*args)
+      # If we're using RubyMotion #to_json isn't available
+      if defined?(Motion::Project::Config)
+        # From BubbleWrap: https://github.com/rubymotion/BubbleWrap/blob/master/motion/core/json.rb#L30-L32
+        NSJSONSerialization.dataWithJSONObject(to_h, options: 0, error: nil).to_str
+      elsif defined?(JSON)
+        to_h.to_json(*args)
+      else
+        raise "#{self.class}#to_json depends on Hash#to_json. Try again after using `require 'json'`."
+      end
     end
 
     private

--- a/lib/dish/plate.rb
+++ b/lib/dish/plate.rb
@@ -28,7 +28,11 @@ module Dish
       @_original_hash
     end
 
-    alias_method :as_hash, :to_h
+    def as_hash
+      # TODO: Add the version number where this was deprecated?
+      warn 'Dish::Plate#as_hash has been deprecated. Use Dish::Plate#to_h.'
+      to_h
+    end
 
     def to_json(*args)
       # If we're using RubyMotion #to_json isn't available like with Ruby's JSON stdlib

--- a/lib/dish/plate.rb
+++ b/lib/dish/plate.rb
@@ -31,7 +31,7 @@ module Dish
     alias_method :as_hash, :to_h
 
     def to_json(*args)
-      # If we're using RubyMotion #to_json isn't available
+      # If we're using RubyMotion #to_json isn't available like with Ruby's JSON stdlib
       if defined?(Motion::Project::Config)
         # From BubbleWrap: https://github.com/rubymotion/BubbleWrap/blob/master/motion/core/json.rb#L30-L32
         NSJSONSerialization.dataWithJSONObject(to_h, options: 0, error: nil).to_str

--- a/lib/dish/plate.rb
+++ b/lib/dish/plate.rb
@@ -30,6 +30,10 @@ module Dish
 
     alias_method :as_hash, :to_h
 
+    def to_json(*args)
+      to_h.to_json(*args)
+    end
+
     private
 
       attr_reader :_original_hash

--- a/test/dish_test.rb
+++ b/test/dish_test.rb
@@ -67,7 +67,7 @@ class DishTest < Test::Unit::TestCase
     assert_nil Dish(nil)
   end
 
-  def test_as_hash
+  def test_to_h
     hash = {
       "a" => "a",
       "b" => "b",
@@ -77,8 +77,8 @@ class DishTest < Test::Unit::TestCase
       }
     }
     dish = Dish(hash)
-    c_hash = dish.c.as_hash
-    assert_equal "Hash", dish.c.as_hash.class.to_s
+    c_hash = dish.c.to_h
+    assert_equal "Hash", dish.c.to_h.class.to_s
     assert_equal hash["c"]["1"], c_hash["1"]
     assert_equal hash["c"]["2"], c_hash["2"]
   end

--- a/test/dish_test.rb
+++ b/test/dish_test.rb
@@ -39,6 +39,10 @@ class DishTest < Test::Unit::TestCase
     assert_equal true,       book.title?
     assert_equal false,      book.active
     assert_equal false,      book.active?
+
+    book.active = nil
+    assert_equal nil,   book.active
+    assert_equal false, book.active?
   end
 
   def test_hash_helper

--- a/test/dish_test.rb
+++ b/test/dish_test.rb
@@ -39,10 +39,6 @@ class DishTest < Test::Unit::TestCase
     assert_equal true,       book.title?
     assert_equal false,      book.active
     assert_equal false,      book.active?
-
-    book.active = nil
-    assert_equal nil,   book.active
-    assert_equal false, book.active?
   end
 
   def test_hash_helper


### PR DESCRIPTION
In response to #2:

Ruby 2.x+ has been using `#to_h` to denote hash conversion.

See this blog post for more information: [All About #to_h in Ruby 2.x](http://www.benjaminoakes.com/2013/03/08/all-about-to_h-in-ruby-2/).
- [x] Rename `Dish::Plate#as_hash` to `Dish::Plate#to_h`
- [x] Create an alias to the original `#as_hash` method
- [x] Define `Dish::Plate#to_json`
- [x] Deprecate `#as_hash` (run `#to_h` in addition to printing a message)
