### PR TITLE
Cache converted values

### DIFF
--- a/lib/dish/plate.rb
+++ b/lib/dish/plate.rb
@@ -12,6 +12,7 @@ module Dish
 
     def initialize(hash)
       @_original_hash = Hash[hash.map { |k, v| [k.to_s, v] }]
+      @_value_cache = {}
     end
 
     def method_missing(method, *args, &block)
@@ -38,7 +39,11 @@ module Dish
 
       def _get_value(key)
         value = _original_hash[key]
-        _convert_value(value, self.class.coercions[key])
+        @_value_cache[_cache_key(value)] ||= _convert_value(value, self.class.coercions[key])
+      end
+
+      def _cache_key(value)
+        [value.object_id, @_original_hash.hash].join('')
       end
 
       def _check_for_presence(key)

--- a/test/coercion_test.rb
+++ b/test/coercion_test.rb
@@ -32,6 +32,23 @@ class DishTest < Test::Unit::TestCase
     assert products.map(&:authors).flatten.all? { |a| a.is_a?(Author) }
   end
 
+  def test_coercion_caching
+    products = api_response.to_dish(Product)
+
+    assert_equal products.first.authors.first.object_id, products.first.authors.first.object_id
+  end
+
+  def test_coercion_cache_busting
+    products = api_response.to_dish(Product)
+
+    author = products.first.authors.first
+    assert_equal author.name, products.first.authors.first.name
+
+    products.first.as_hash['authors'].first['name'] = 'Johnny Cache'
+
+    assert_not_equal author.name, products.first.authors.first.name
+  end
+
   private
 
     class Author < Dish::Plate; end


### PR DESCRIPTION
Added some basic caching for converted values to prevent unnecessary object recreations.

**Benchmark:**

``` ruby
class Author < Dish::Plate; end
class Product < Dish::Plate
  coerce :updated_at, ->(value) { Time.parse(value) }
  coerce :authors, Author
end

api_response = [
  {
    title: "Test Product",
    updated_at: "2013-01-28 13:23:11",
    authors: [
      { id: 1, name: "First Author" },
      { id: 2, name: "Second Author" }
    ]
  }
]

products = api_response.to_dish(Product)
Benchmark.realtime{
  50000.times{
    products.first.updated_at
    products.first.authors
  }
}
```

```
Without cache: 2.64122 seconds
With cache: 0.993074 seconds
```
