### PR TITLE
Respond correctly to 'respond_to?'

### DIFF
--- a/lib/dish/plate.rb
+++ b/lib/dish/plate.rb
@@ -19,7 +19,7 @@ module Dish
       method = method.to_s
       if method.end_with?("?")
         key = method[0..-2]
-        _check_for_presence(key)
+        !!_get_value(key)
       else
         _get_value(method)
       end
@@ -47,7 +47,7 @@ module Dish
       end
 
       def _check_for_presence(key)
-        !!_get_value(key)
+        _original_hash.key?(key)
       end
 
       def _convert_value(value, coercion)

--- a/test/dish_test.rb
+++ b/test/dish_test.rb
@@ -24,7 +24,7 @@ class DishTest < Test::Unit::TestCase
     assert_respond_to book,  :authors
     refute_respond_to book,  :doesnotexist
     assert_nothing_raised do
-      m = book.method(:title)
+      book.method(:title)
     end
   end
 

--- a/test/dish_test.rb
+++ b/test/dish_test.rb
@@ -107,4 +107,13 @@ class DishTest < Test::Unit::TestCase
       assert_instance_of Dish::Plate, d
     end
   end
+
+  def test_respond_to
+    hash = { a: 1, b: true, c: false, d: nil }
+    dish = Dish(hash)
+
+    hash.each do |key, _|
+      assert_respond_to dish, key
+    end
+  end
 end


### PR DESCRIPTION
Fixes (in my opinion) wrong result for `respond_to?`. If the hash contained the `key`, `respond_to?(key)` should return `true`.

Example (before):

``` ruby
hash = {a: nil}
 => {:a=>nil} 
Dish(hash).respond_to?(:a)
 => false

hash = {a: false}
 => {:a=>false} 
Dish(hash).try(:a)
 => nil
```

Example (after):

``` ruby
hash = {a: nil}
 => {:a=>nil} 
Dish(hash).respond_to?(:a)
 => true 

hash = {a: false}
 => {:a=>false} 
Dish(hash).try(:a)
 => false
```
